### PR TITLE
Fix: structural integrity during copy

### DIFF
--- a/src/Containers-BinarySearchTree-Tests/CTBinarySearchTreeTest.class.st
+++ b/src/Containers-BinarySearchTree-Tests/CTBinarySearchTreeTest.class.st
@@ -117,6 +117,27 @@ CTBinarySearchTreeTest >> testCopy [
 ]
 
 { #category : 'tests' }
+CTBinarySearchTreeTest >> testCopyPreservesStructure [
+
+	| copiedTree |
+	
+	tree add: 50.
+	tree add: 30.
+	tree add: 70.
+	
+	self assert: tree height equals: 2.
+	self assert: tree root contents equals: 50.
+	
+	copiedTree := tree copy.
+	
+	self assert: copiedTree height equals: tree height.
+	self assert: copiedTree root contents equals: tree root contents.
+	
+	self assert: copiedTree root left contents equals: 30.
+	self assert: copiedTree root right contents equals: 70.
+]
+
+{ #category : 'tests' }
 CTBinarySearchTreeTest >> testDoMethod [
 
 	| result |

--- a/src/Containers-BinarySearchTree/CTBinarySearchTree.class.st
+++ b/src/Containers-BinarySearchTree/CTBinarySearchTree.class.st
@@ -84,7 +84,7 @@ CTBinarySearchTree >> copy [
 
 	| newTree |
 	newTree := self class new.
-	self inOrderDo: [ :each | newTree add: each ].
+	self preOrderDo: [ :each | newTree add: each ].
 	^ newTree
 ]
 


### PR DESCRIPTION
This PR fixes a critical structural bug in the `copy` method that caused the copied tree to degrade into a right-skewed linked list.

**The Issue:**
The previous implementation used `inOrderDo:` to populate the new tree. Because `inOrderDo:` yields elements in strictly ascending order, inserting them sequentially into a new BST causes it to build a straight line of right-child nodes, ruining the **O(_log N_)** performance.

**The Fix:**
Changed the traversal to `preOrderDo:`. By extracting and inserting the root first, then the left and right subtrees, the copied tree perfectly reconstructs the original shape.

**Changes made:**
- Updated `CTBinarySearchTree >> copy` to use `preOrderDo:`.
- Added `CTBinarySearchTreeTest >> testCopyPreservesStructure` to assert that tree height and node placements remain identical after a copy operation.

and all tests **Green** now :)

<img width="984" height="701" alt="image" src="https://github.com/user-attachments/assets/f431ddf0-fb8a-404e-975e-fdbcc2e6ea1a" />

Closes #7 